### PR TITLE
Fix `Illegal Instruction` in Docker image by not using `-march=native`

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -27,7 +27,7 @@ RUN wget https://downloads.sourceforge.net/reactos/RosBE-Unix-2.2.1.tar.bz2 \
     && tar -xjf RosBE-Unix-2.2.1.tar.bz2 \
     && rm RosBE-Unix-2.2.1.tar.bz2 \
     && cd RosBE-Unix-2.2.1 \
-    && echo yes | bash CFLAGS="-pipe -O2 -Wl,-S -g0 -march=core2" RosBE-Builder.sh /usr/local/RosBE \
+    && echo yes | CFLAGS="-pipe -O2 -Wl,-S -g0 -march=core2" bash RosBE-Builder.sh /usr/local/RosBE \
     && cd .. \
     && rm -rf RosBE-Unix-2.2.1
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -27,7 +27,7 @@ RUN wget https://downloads.sourceforge.net/reactos/RosBE-Unix-2.2.1.tar.bz2 \
     && tar -xjf RosBE-Unix-2.2.1.tar.bz2 \
     && rm RosBE-Unix-2.2.1.tar.bz2 \
     && cd RosBE-Unix-2.2.1 \
-    && echo yes | bash RosBE-Builder.sh /usr/local/RosBE \
+    && echo yes | bash CFLAGS="-pipe -O2 -Wl,-S -g0 -march=core2" RosBE-Builder.sh /usr/local/RosBE \
     && cd .. \
     && rm -rf RosBE-Unix-2.2.1
 


### PR DESCRIPTION
`RosBE-Builder.sh` defaults to using `-march=native`. Images built on the latest CPUs (as the GitHub Actions CI machines have) will then fail on older build machines.

These flags are already used for the Debian package: https://github.com/reactos/RosBE/blob/aff79fe611c5b515277e2d8fc241a2017e9b42bc/RosBE-Unix/Base-i386_debian/rules

@learn-more Please have a look if this is fine for you and let GitHub Actions build a new Docker image. Thanks!